### PR TITLE
Update to 1.19.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx2048M
 
-minecraft_version=1.19
+minecraft_version=1.19.4
 enabled_platforms=quilt,fabric,forge
 
 archives_base_name=examplemod
@@ -9,10 +9,10 @@ maven_group=net.examplemod
 
 architectury_version=5.12.42
 
-fabric_loader_version=0.14.9
-fabric_api_version=0.58.0+1.19
+fabric_loader_version=0.14.18
+fabric_api_version=0.76.0+1.19.4
 
-forge_version=1.19-41.1.0
+forge_version=1.19.4-45.0.27
 
-quilt_loader_version=0.17.2-beta.3
-quilt_fabric_api_version=2.0.0-beta.9+0.58.0-1.19
+quilt_loader_version=0.18.6
+quilt_fabric_api_version=6.0.0-beta.2+0.76.0-1.19.4


### PR DESCRIPTION
Updated `mcmod-test-project` mod to 1.19.4

# build.gradle

| Property        | Old           | New          |
|-----------------|---------------|--------------|
| **Fabric loom** | 0.12-SNAPSHOT | 1.1-SNAPSHOT |

# gradle.properties

| Property           | Old                      | New                        |
|--------------------|--------------------------|----------------------------|
| Version            | 1.0.0                    |                            |
| Minecraft          | 1.19.4                   |                            |
| Architectury       | 5.12.42                  |                            |
| Fabric Loader      | 0.14.9                   | 0.14.18                    |
| Fabric API         | 0.58.0+1.19              | 0.76.0+1.19.4              |
| Forge              | 1.19-41.1.0              | 1.19.4-45.0.27             |
| Quilt Loader       | 0.17.2-beta.3            | 0.18.6                     |
| Quilted Fabric API | 2.0.0-beta.9+0.58.0-1.19 | 6.0.0-beta.2+0.76.0-1.19.4 |

# Mapping Migrations

## MixinArmorFeatureRenderer

getArmor() -> getModel()
usesSecondLayer() -> usesInnerModel()
setAttributes() -> copyBipedStateTo()

## ArmoredElytraModelProvider

UnclampedModelPredicateProvider -> ClampedModelPredicateProvider
