### PR TITLE
Update to 1.16.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ maven_group=net.examplemod
 
 architectury_version=1.32.66
 
-fabric_loader_version=0.14.9
+fabric_loader_version=0.14.18
 fabric_api_version=0.42.0+1.16
 
 forge_version=1.16.5-36.2.39


### PR DESCRIPTION
Updated `mcmod-test-project` to 1.16.5

# build.gradle

| Property        | Old           | New          |
|-----------------|---------------|--------------|
| **Fabric loom** | 0.12-SNAPSHOT | 1.1-SNAPSHOT |

# gradle.properties

| Property      | Old            | New     |
|---------------|----------------|---------|
| Version       | 1.0.0          |         |
| Minecraft     | 1.16.5         |         |
| Architectury  | 1.32.66        |         |
| Fabric Loader | 0.14.9         | 0.14.18 |
| Fabric API    | 0.42.0+1.16    |         |
| Forge         | 1.16.5-36.2.39 |         |

# Mapping Migrations

## MixinArmorFeatureRenderer

getArmor() -> getModel()
usesSecondLayer() -> usesInnerModel()
setAttributes() -> copyBipedStateTo()

## ArmoredElytraModelProvider

UnclampedModelPredicateProvider -> ClampedModelPredicateProvider
