### PR TITLE
Update to 1.17.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ maven_group=net.examplemod
 
 architectury_version=2.10.12
 
-fabric_loader_version=0.14.9
+fabric_loader_version=0.14.18
 fabric_api_version=0.46.1+1.17
 
 forge_version=1.17.1-37.1.1


### PR DESCRIPTION
Updated `mcmod-test-project` to 1.17.1

# build.gradle

| Property        | Old           | New          |
|-----------------|---------------|--------------|
| **Fabric loom** | 0.12-SNAPSHOT | 1.1-SNAPSHOT |

# gradle.properties

| Property      | Old           | New     |
|---------------|---------------|---------|
| Version       | 1.0.0         |         |
| Minecraft     | 1.17.1        |         |
| Architectury  | 2.10.12       |         |
| Fabric Loader | 0.14.9        | 0.14.18 |
| Fabric API    | 0.46.1+1.17   |         |
| Forge         | 1.17.1-37.1.1 |         |

# Mapping Migrations

## MixinArmorFeatureRenderer

getArmor() -> getModel()
usesSecondLayer() -> usesInnerModel()
setAttributes() -> copyBipedStateTo()

## ArmoredElytraModelProvider

UnclampedModelPredicateProvider -> ClampedModelPredicateProvider
