### PR TITLE
Update to 1.18.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx2048M
 
-minecraft_version=1.18.1
+minecraft_version=1.18.2
 enabled_platforms=fabric,forge
 
 archives_base_name=examplemod
@@ -9,10 +9,10 @@ maven_group=net.examplemod
 
 architectury_version=3.9.66
 
-fabric_loader_version=0.14.9
-fabric_api_version=0.46.6+1.18
+fabric_loader_version=0.14.18
+fabric_api_version=0.76.0+1.18.2
 
-forge_version=1.18.1-39.1.2
+forge_version=1.18.2-40.2.1
 
 
 


### PR DESCRIPTION
Updated `mcmod-test-project` to 1.18.2

# build.gradle

| Property        | Old           | New          |
|-----------------|---------------|--------------|
| **Fabric loom** | 0.12-SNAPSHOT | 1.1-SNAPSHOT |

# gradle.properties

| Property      | Old           | New           |
|---------------|---------------|---------------|
| Version       | 1.0.0         |               |
| Minecraft     | 1.18.1        | 1.18.2        |
| Architectury  | 3.9.66        |               |
| Fabric Loader | 0.14.9        | 0.14.18       |
| Fabric API    | 0.46.6+1.18   | 0.76.0+1.18.2 |
| Forge         | 1.18.1-39.1.2 | 1.18.2-40.2.1 |

# Mapping Migrations

## MixinArmorFeatureRenderer

getArmor() -> getModel()
usesSecondLayer() -> usesInnerModel()
setAttributes() -> copyBipedStateTo()

## ArmoredElytraModelProvider

UnclampedModelPredicateProvider -> ClampedModelPredicateProvider
